### PR TITLE
Fix querystring encoding of RequestType and loosen base bounds

### DIFF
--- a/auth0.cabal
+++ b/auth0.cabal
@@ -52,7 +52,7 @@ library
                      , Auth0.Management.Tenants
                      , Auth0.Management.Tickets
   build-depends:       aeson
-                     , base >= 4.9 && <= 4.10
+                     , base >= 4.9 && <= 4.11
                      , bytestring
                      , containers
                      , exceptions

--- a/src/Auth0/Request.hs
+++ b/src/Auth0/Request.hs
@@ -36,10 +36,10 @@ execRequest
 execRequest (Auth t) (API m p) a b hs = do
   let req = (setRequestMethod . encodeUtf8 . T.pack . show) m
           . (setRequestHost . untag) t
-          . setRequestPort 443 
+          . setRequestPort 443
           . setRequestSecure True
           . setRequestPath p
-          . (\r -> maybe r (\a' -> (setRequestQueryString . buildRequest) a' r) a)
+          . maybe id (setRequestQueryString . buildRequest) a
           . setRequestBodyJSON b
           . setRequestHeaders (fromMaybe [] hs)
           $ defaultRequest

--- a/src/Auth0/Types.hs
+++ b/src/Auth0/Types.hs
@@ -87,7 +87,10 @@ instance ToJSON ResponseType where
   toJSON Token = "token"
 
 instance ToField ResponseType where
-  toField t v = (t, (Just . pack . show . encode) v)
+  toField t v = (t, (Just $ case v of
+                        Code -> "code"
+                        Token -> "token"
+                    ))
 
 data GrantType
   = Password


### PR DESCRIPTION
Hello!

After this change:

```
*Test Auth0.Types> l
Login {responseType = Code, clientId = Tagged "ouzxAjuPtXYg9F6QM5oNHJUFb7GKEBDL", connection = Nothing, redirectUri = "http://localhost:8080", state = Just "myTestState", additionalParameters = Nothing}
*Test Auth0.Types> buildRequest l
[("response_type",Just "code"),("client_id",Just "ouzxAjuPtXYg9F6QM5oNHJUFb7GKEBDL"),("connection",Nothing),("redirect_uri",Just "http://localhost:8080"),("state",Just "myTestState")]
```

Before the change, `code` was wrapped with extra quotations marks, which was causing auth0.com to reject the login request.