### PR TITLE
allow app and user metadata to have any shape

### DIFF
--- a/src/Auth0/Management/Users.hs
+++ b/src/Auth0/Management/Users.hs
@@ -141,7 +141,7 @@ data UserCreate
   , emailVerified :: Maybe Bool
   , verifyEmail   :: Maybe Bool
   , phoneVerified :: Maybe Bool
-  , appMd   :: Maybe (Map Text Text)
+  , appMetadata   :: Maybe (Map Text Text)
   } deriving (Generic, Show)
 
 instance ToJSON UserCreate where

--- a/src/Auth0/Management/Users.hs
+++ b/src/Auth0/Management/Users.hs
@@ -90,7 +90,7 @@ instance ToJSON Identity where
       f "isSocial" = "isSocial"
       f v          = camelTo2 '_' v
 
-data UserResponse
+data UserResponse appMd userMd
   = UserResponse
   { email         :: Maybe Text
   , emailVerified :: Maybe Bool
@@ -101,8 +101,8 @@ data UserResponse
   , createdAt     :: Maybe Text
   , updatedAt     :: Maybe Text
   , identities    :: Maybe [Identity]
-  , appMetadata   :: Maybe (Map Text Text)
-  , userMetadata  :: Maybe (Map Text Text)
+  , appMetadata   :: Maybe appMd
+  , userMetadata  :: Maybe userMd
   , picture       :: Maybe Text
   , name          :: Maybe Text
   , nickname      :: Maybe Text
@@ -118,8 +118,8 @@ data UserResponse
 deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' } ''UserResponse
 
 runGetUsers
-  :: (MonadIO m, MonadThrow m)
-  => Auth -> Maybe User -> m (Auth0Response [UserResponse])
+  :: (MonadIO m, MonadThrow m, FromJSON appMd, FromJSON userMd)
+  => Auth -> Maybe User -> m (Auth0Response [UserResponse appMd userMd])
 runGetUsers a o =
   let api = API Get "/api/v2/users"
   in execRequest a api o (Nothing :: Maybe ()) Nothing
@@ -141,7 +141,7 @@ data UserCreate
   , emailVerified :: Maybe Bool
   , verifyEmail   :: Maybe Bool
   , phoneVerified :: Maybe Bool
-  , appMetadata   :: Maybe (Map Text Text)
+  , appMd   :: Maybe (Map Text Text)
   } deriving (Generic, Show)
 
 instance ToJSON UserCreate where
@@ -149,8 +149,8 @@ instance ToJSON UserCreate where
     genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
 
 runCreateUser
-  :: (MonadIO m, MonadThrow m)
-  => Auth -> UserCreate -> m (Auth0Response UserResponse)
+  :: (MonadIO m, MonadThrow m, FromJSON appMd, FromJSON userMd)
+  => Auth -> UserCreate -> m (Auth0Response (UserResponse appMd userMd))
 runCreateUser a o =
   let api = API Post "/api/v2/users"
   in execRequest a api (Nothing :: Maybe ()) (Just o) Nothing
@@ -171,8 +171,8 @@ instance ToRequest UserGet where
     ]
 
 runGetUser
-  :: (MonadIO m, MonadThrow m)
-  => Auth -> Text -> Maybe UserGet -> m (Auth0Response UserResponse)
+  :: (MonadIO m, MonadThrow m, FromJSON appMd, FromJSON userMd)
+  => Auth -> Text -> Maybe UserGet -> m (Auth0Response (UserResponse appMd userMd))
 runGetUser a i o =
   let api = API Get ("/api/v2/users/" <> encodeUtf8 i)
   in execRequest a api o (Nothing :: Maybe ()) Nothing
@@ -191,8 +191,8 @@ runDeleteUser a i =
 -- PATCH /api/v2/users/{id}
 
 runUpdateUser
-  :: (MonadIO m, MonadThrow m)
-  => Auth -> Text -> UserCreate -> m (Auth0Response UserResponse)
+  :: (MonadIO m, MonadThrow m, FromJSON appMd, FromJSON userMd)
+  => Auth -> Text -> UserCreate -> m (Auth0Response (UserResponse appMd userMd))
 runUpdateUser a i o =
   let api = API Update ("/api/v2/users/" <> encodeUtf8 i)
   in execRequest a api (Nothing :: Maybe ()) (Just o) Nothing

--- a/src/Auth0/Management/UsersByEmail.hs
+++ b/src/Auth0/Management/UsersByEmail.hs
@@ -3,6 +3,7 @@ module Auth0.Management.UsersByEmail where
 --------------------------------------------------------------------------------
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO)
+import Data.Aeson (FromJSON)
 import Data.Text
 --------------------------------------------------------------------------------
 import Auth0.Management.Users (UserResponse)
@@ -30,8 +31,8 @@ instance ToRequest UsersByEmail where
     ]
 
 runGetUsersByEmail
-  :: (MonadIO m, MonadThrow m)
-  => Auth -> UsersByEmail -> m (Auth0Response [UserResponse])
+  :: (MonadIO m, MonadThrow m, FromJSON appMd, FromJSON userMd)
+  => Auth -> UsersByEmail -> m (Auth0Response [UserResponse appMd userMd])
 runGetUsersByEmail a o =
   let api = API Get "/api/v2/users-by-email"
   in execRequest a api (Just o) (Nothing :: Maybe ()) Nothing


### PR DESCRIPTION
Since Auth0 allows the app and user metadata fields to have any arbitrary shape, I don't think it makes sense to restrict them to `Map Text Text`, especially since these are the only fields that Auth0 lets you put data for your application domain. I've replaced the types of both `appMetadata` and `userMetadata` with type variables to allow for this, and added `FromJSON` constraints at usage sites to deal with decoding.