### PR TITLE
 fix parsers for user records with prefixed fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 dist
+dist-newstyle
+.env
+

--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ export AUTH0_CONNECTION=<connection>
 
 nix-shell --run 'cabal test --show-details=always --test-options=--color'
 ```
+
+# Developing
+
+```bash
+nix-shell --run 'ghcid --command="cabal new-repl auth0"'
+```

--- a/auth0.cabal
+++ b/auth0.cabal
@@ -73,6 +73,7 @@ test-suite auth0-test
   main-is:             Main.hs
   build-depends:       auth0
                      , base >= 4.9 && <= 4.11
+                     , aeson
                      , bytestring
                      , hspec
                      , random

--- a/src/Auth0/Management/Users.hs
+++ b/src/Auth0/Management/Users.hs
@@ -10,9 +10,9 @@ import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson
 import Data.Aeson.TH
-import Data.Map
+import Data.Map hiding (drop)
 import Data.Monoid ((<>))
-import Data.Text
+import Data.Text hiding (drop)
 import Data.Text.Encoding
 import GHC.Generics
 --------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ data ProfileData
   , pdFamilyName    :: Maybe Text
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' } ''ProfileData
+deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 } ''ProfileData
 
 data Identity
   = Identity
@@ -79,16 +79,16 @@ data Identity
 
 instance FromJSON Identity where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = f }
+    genericParseJSON defaultOptions { fieldLabelModifier = f . drop 1 }
     where
-      f "isSocial" = "isSocial"
+      f "IsSocial" = "isSocial"
       f v          = camelTo2 '_' v
 
 instance ToJSON Identity where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = f }
+    genericToJSON defaultOptions { fieldLabelModifier = f . drop 1 }
     where
-      f "isSocial" = "isSocial"
+      f "IsSocial" = "isSocial"
       f v          = camelTo2 '_' v
 
 data UserResponse appMd userMd
@@ -116,7 +116,7 @@ data UserResponse appMd userMd
   , urFamilyName    :: Maybe Text
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' } ''UserResponse
+deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 } ''UserResponse
 
 runGetUsers
   :: (MonadIO m, MonadThrow m, FromJSON appMd, FromJSON userMd)
@@ -147,7 +147,7 @@ data UserCreate appMd userMd
 
 instance (ToJSON appMd, ToJSON userMd) => ToJSON (UserCreate appMd userMd) where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 }
 
 runCreateUser
   :: (MonadIO m, MonadThrow m, FromJSON appMd, FromJSON userMd, ToJSON appMd, ToJSON userMd, Show appMd, Show userMd)
@@ -218,7 +218,7 @@ data UserEnrollment
 
 instance FromJSON UserEnrollment where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = f }
+    genericParseJSON defaultOptions { fieldLabelModifier = f . drop 2 }
     where
       f "type" = "etype"
       f v      = camelTo2 '_' v
@@ -269,7 +269,7 @@ data UserLog
 
 instance FromJSON UserLog where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 }
 
 runGetUserLogs
   :: (MonadIO m, MonadThrow m)
@@ -339,7 +339,7 @@ data LinkAccount
 
 instance ToJSON LinkAccount where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 }
 
 runUserLinkAccount
   :: (MonadIO m, MonadThrow m)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Main where
 
 --------------------------------------------------------------------------------
+import Data.Aeson
 import qualified Data.ByteString.Char8 as BS (pack)
 import Data.Maybe
 import Data.Monoid ((<>))
@@ -12,6 +15,7 @@ import Test.Hspec
 --------------------------------------------------------------------------------
 import Auth0.Authentication.GetToken
 import Auth0.Authentication.Signup
+import Auth0.Management.Users
 import Auth0.Types
 --------------------------------------------------------------------------------
 
@@ -46,7 +50,7 @@ main = do
     describe "Authentication.Signup" $
       it "Signup" $ do
         let ath = mkAuth ((BS.pack . fromJust) tnt)
-            pay = Signup 
+            pay = Signup
                     ((mkClientId . pack . fromJust) cid)
                     usr
                     pwd
@@ -59,7 +63,7 @@ main = do
     describe "Authentication.GetToken" $
       it "Resource Owner Password" $ do
         let ath = mkAuth ((BS.pack . fromJust) tnt)
-            pay = GetTokenResourceOwner 
+            pay = GetTokenResourceOwner
                     Password
                     ((mkClientId . pack . fromJust) cid)
                     ((Just . mkClientSecret . pack . fromJust) cst)
@@ -74,3 +78,19 @@ main = do
         case resPayload res of
           Nothing   -> return ()
           Just res' -> tokenType res' `shouldBe` "Bearer"
+
+    describe "Management.Users" $
+      it "Get Users" $ do
+        let auth = mkAuth ((BS.pack . fromJust) tnt)
+            pay = GetTokenClientCreds
+                  ClientCredentials
+                  (mkClientId . pack . fromJust $ cid)
+                  (mkClientSecret . pack . fromJust $ cst)
+                  (pack . fromJust $ aud)
+        tknResponse <- runGetToken auth pay
+        let tokenAuth = fromJust $ do
+             tkn <- accessToken <$> resPayload tknResponse
+             pure $ mkTokenAuth ((BS.pack . fromJust) tnt) tkn
+        res :: Auth0Response [UserResponse Value Value] <- runGetUsers tokenAuth Nothing
+        resError res `shouldBe` Nothing
+        isJust (resPayload res) `shouldBe` True


### PR DESCRIPTION
The record field prefixes added in #5 broke the generic JSON parsers, and this fixes that.

Additionally:
* adds a test case for the Management.Users module
* uses `eitherDecode` in `execRequest` to get parser error information, which we should be able to conditionally log based on a configuration variable. for now, it's just useful for developers to more easily add log statements when debugging parse errors.
* adds development documentation