### PR TITLE
omitting nothing fields from json body

### DIFF
--- a/src/Auth0/Authentication/GetToken.hs
+++ b/src/Auth0/Authentication/GetToken.hs
@@ -30,7 +30,7 @@ data GetToken
 
 instance ToJSON GetToken where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 -- Authorize Code (PKCE)
 
@@ -45,7 +45,7 @@ data GetTokenPKCE
 
 instance ToJSON GetTokenPKCE where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 -- Client Credentials
 
@@ -59,7 +59,7 @@ data GetTokenClientCreds
 
 instance ToJSON GetTokenClientCreds where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 -- Resource Owner Password
 
@@ -77,7 +77,7 @@ data GetTokenResourceOwner
 
 instance ToJSON GetTokenResourceOwner where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 -- Request Headers
 
@@ -101,7 +101,7 @@ data GetTokenResponse
 
 instance FromJSON GetTokenResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetToken
   :: (MonadIO m, MonadThrow m, ToJSON a, Show a)
@@ -125,7 +125,7 @@ data GetTokenResourceOwnerMFA
 
 instance ToJSON GetTokenResourceOwnerMFA where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 -- Response
 
@@ -138,7 +138,7 @@ data GetTokenResourceOwnerMFAResponse
 
 instance FromJSON GetTokenResourceOwnerMFAResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetTokenMFA
   :: (MonadIO m, MonadThrow m)
@@ -164,7 +164,7 @@ data GetTokenVerifyMFAOTP
 
 instance ToJSON GetTokenVerifyMFAOTP where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 --------------------------------------------------------------------------------
 -- POST /oauth/token
@@ -183,7 +183,7 @@ data GetTokenVerifyMFAOOB
 
 instance ToJSON GetTokenVerifyMFAOOB where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 -- Verify MFA using a recovery code
 
@@ -198,7 +198,7 @@ data GetTokenVerifyRecoveryCode
 
 instance ToJSON GetTokenVerifyRecoveryCode where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 -- Refresh Token
 
@@ -212,4 +212,4 @@ data GetTokenRefresh
 
 instance ToJSON GetTokenRefresh where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }

--- a/src/Auth0/Authentication/Impersonation.hs
+++ b/src/Auth0/Authentication/Impersonation.hs
@@ -43,7 +43,7 @@ data Impersonate
 
 instance ToJSON Impersonate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runImpersonate
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Authentication/Passwordless.hs
+++ b/src/Auth0/Authentication/Passwordless.hs
@@ -47,7 +47,7 @@ data GetCodeOrLink
 
 instance ToJSON GetCodeOrLink where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetCodeOrLink
   :: (MonadIO m, MonadThrow m)
@@ -70,7 +70,7 @@ data AuthenticateUser
 
 instance ToJSON AuthenticateUser where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runAuthenticateUser
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Authentication/RevokeRefreshToken.hs
+++ b/src/Auth0/Authentication/RevokeRefreshToken.hs
@@ -24,7 +24,7 @@ data RevokeRefreshToken
 
 instance ToJSON RevokeRefreshToken where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runRevokeRefreshToken
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Authentication/Signup.hs
+++ b/src/Auth0/Authentication/Signup.hs
@@ -28,7 +28,7 @@ data Signup
 
 instance ToJSON Signup where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data SignupResponse
   = SignupResponse
@@ -39,7 +39,7 @@ data SignupResponse
 
 instance FromJSON SignupResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runSignup
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Authentication/UserProfile.hs
+++ b/src/Auth0/Authentication/UserProfile.hs
@@ -31,7 +31,7 @@ data UserProfileResponse
 
 instance FromJSON UserProfileResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runUserProfile
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/ClientGrants.hs
+++ b/src/Auth0/Management/ClientGrants.hs
@@ -46,7 +46,7 @@ data ClientGrantResponse
 
 instance FromJSON ClientGrantResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetClientGrants
   :: (MonadIO m, MonadThrow m)
@@ -67,7 +67,7 @@ data ClientGrantCreate
 
 instance ToJSON ClientGrantCreate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateClientGrant
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Clients.hs
+++ b/src/Auth0/Management/Clients.hs
@@ -52,11 +52,11 @@ data JwtConfiguration
 
 instance FromJSON JwtConfiguration where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 instance ToJSON JwtConfiguration where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data EncryptionKey
   = EncryptionKey
@@ -67,11 +67,11 @@ data EncryptionKey
 
 instance FromJSON EncryptionKey where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 instance ToJSON EncryptionKey where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data Android
   = Android
@@ -81,11 +81,11 @@ data Android
 
 instance FromJSON Android where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 instance ToJSON Android where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data IOS
   = IOS
@@ -95,11 +95,11 @@ data IOS
 
 instance FromJSON IOS where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 instance ToJSON IOS where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data Mobile
   = Mobile
@@ -145,7 +145,7 @@ data ClientResponse
 
 instance FromJSON ClientResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetClients
   :: (MonadIO m, MonadThrow m)
@@ -192,7 +192,7 @@ data ClientCreate
 
 instance ToJSON ClientCreate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateClient
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Connections.hs
+++ b/src/Auth0/Management/Connections.hs
@@ -58,7 +58,7 @@ data ConnectionResponse
 
 instance FromJSON ConnectionResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetConnections
   :: (MonadIO m, MonadThrow m)
@@ -84,7 +84,7 @@ data Options
 
 instance ToJSON Options where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data ConnectionCreate
   = ConnectionCreate
@@ -98,7 +98,7 @@ data ConnectionCreate
 
 instance ToJSON ConnectionCreate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateConnection
   :: (MonadIO m, MonadThrow m)
@@ -152,7 +152,7 @@ data ConnectionUpdate
 
 instance ToJSON ConnectionUpdate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runUpdateConnection
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/DeviceCredentials.hs
+++ b/src/Auth0/Management/DeviceCredentials.hs
@@ -52,7 +52,7 @@ data DeviceCredentialResponse
 
 instance FromJSON DeviceCredentialResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = f }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = f }
     where
       f "type" = "ctype"
       f v      = camelTo2 '_' v
@@ -78,7 +78,7 @@ data DeviceCredentialCreate
 
 instance ToJSON DeviceCredentialCreate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = f }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = f }
     where
       f "ctype" = "type"
       f v       = camelTo2 '_' v

--- a/src/Auth0/Management/Emails.hs
+++ b/src/Auth0/Management/Emails.hs
@@ -49,7 +49,7 @@ data Credentials
 
 instance FromJSON Credentials where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data EmailProviderResponse
   = EmailProviderResponse
@@ -62,7 +62,7 @@ data EmailProviderResponse
 
 instance FromJSON EmailProviderResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetEmailProviders
   :: (MonadIO m, MonadThrow m)
@@ -91,7 +91,7 @@ data CredentialsUpdate
 
 instance ToJSON CredentialsUpdate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data EmailProviderUpdate
   = EmailProviderUpdate
@@ -104,7 +104,7 @@ data EmailProviderUpdate
 
 instance ToJSON EmailProviderUpdate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runUpdateEmailProvider
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Grants.hs
+++ b/src/Auth0/Management/Grants.hs
@@ -43,7 +43,7 @@ data GrantResponse
 
 instance FromJSON GrantResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetGrants
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Guardian.hs
+++ b/src/Auth0/Management/Guardian.hs
@@ -32,7 +32,7 @@ data Guardian
 
 instance FromJSON Guardian where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetGuardians
   :: (MonadIO m, MonadThrow m)
@@ -57,7 +57,7 @@ data Enrollment
 
 instance FromJSON Enrollment where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetGuardianEnrollments
   :: (MonadIO m, MonadThrow m)
@@ -87,11 +87,11 @@ data Template
 
 instance FromJSON Template where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 instance ToJSON Template where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetGuardianTemplate
   :: (MonadIO m, MonadThrow m)
@@ -124,7 +124,7 @@ data PushNotification
 
 instance FromJSON PushNotification where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetGuardianPushNotification
   :: (MonadIO m, MonadThrow m)
@@ -149,7 +149,7 @@ data GuardianEnrollmentTicket
 
 instance ToJSON GuardianEnrollmentTicket where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data GuardianEnrollmentTicketResponse
   = GuardianEnrollmentTicketResponse
@@ -159,7 +159,7 @@ data GuardianEnrollmentTicketResponse
 
 instance FromJSON GuardianEnrollmentTicketResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateGuardianEnrollmentTicket
   :: (MonadIO m, MonadThrow m)
@@ -176,7 +176,7 @@ data GuardianFactorUpdate
   { enabled :: Bool
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' } ''GuardianFactorUpdate
+deriveJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' } ''GuardianFactorUpdate
 
 runUpdateGuardianFactor
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Jobs.hs
+++ b/src/Auth0/Management/Jobs.hs
@@ -37,14 +37,14 @@ data JobResponse
 
 instance FromJSON JobResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = f }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = f }
     where
       f "text" = "jtype"
       f v      = camelTo2 '_' v
 
 instance ToJSON JobResponse where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = f }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = f }
     where
       f "jtext" = "type"
       f v       = camelTo2 '_' v
@@ -79,7 +79,7 @@ data JobResultsResponse
 
 instance FromJSON JobResultsResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetJobResults
   :: (MonadIO m, MonadThrow m)
@@ -101,7 +101,7 @@ data JobExportCreate
 
 instance ToJSON JobExportCreate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateJobExport
   :: (MonadIO m, MonadThrow m)
@@ -127,7 +127,7 @@ data JobVerificationEmail
 
 instance ToJSON JobVerificationEmail where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 data JobVerificationEmailResponse
   = JobVerificationEmailResponse
@@ -139,7 +139,7 @@ data JobVerificationEmailResponse
 
 instance FromJSON JobVerificationEmailResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateJobVerificationEmail
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/ResourceServers.hs
+++ b/src/Auth0/Management/ResourceServers.hs
@@ -37,7 +37,7 @@ data ResourceServerResponse
 
 instance FromJSON ResourceServerResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetResourceServers
   :: (MonadIO m, MonadThrow m)
@@ -64,7 +64,7 @@ data ResourceServerCreate
 
 instance ToJSON ResourceServerCreate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateResourceServer
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Rules.hs
+++ b/src/Auth0/Management/Rules.hs
@@ -49,7 +49,7 @@ data RuleResponse
 
 instance FromJSON RuleResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetRules
   :: (MonadIO m, MonadThrow m)
@@ -71,7 +71,7 @@ data RuleCreate
 
 instance ToJSON RuleCreate where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateRule
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Stats.hs
+++ b/src/Auth0/Management/Stats.hs
@@ -46,7 +46,7 @@ data StatsDailyResponse
 
 instance FromJSON StatsDailyResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetStatsDaily
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Tenants.hs
+++ b/src/Auth0/Management/Tenants.hs
@@ -42,7 +42,7 @@ data ChangePassword
   , html    :: Maybe Text
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' } ''ChangePassword
+deriveJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' } ''ChangePassword
 
 data GuardianMfaPage
   = GuardianMfaPage
@@ -50,7 +50,7 @@ data GuardianMfaPage
   , html    :: Maybe Text
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' } ''GuardianMfaPage
+deriveJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' } ''GuardianMfaPage
 
 data ErrorPage
   = ErrorPage
@@ -59,7 +59,7 @@ data ErrorPage
   , url         :: Maybe Text
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' } ''ErrorPage
+deriveJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' } ''ErrorPage
 
 data Flags
   = Flags
@@ -70,7 +70,7 @@ data Flags
   , enablePipeline2         :: Maybe Bool
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' } ''Flags
+deriveJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' } ''Flags
 
 data TenantSettingResponse
   = TenantSettingResponse
@@ -88,7 +88,7 @@ data TenantSettingResponse
   , sessionLifetime   :: Maybe Double
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' } ''TenantSettingResponse
+deriveJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' } ''TenantSettingResponse
 
 runGetTenantSettings
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Tickets.hs
+++ b/src/Auth0/Management/Tickets.hs
@@ -28,7 +28,7 @@ data TicketEmailVerification
 
 instance ToJSON TicketEmailVerification where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 -- Response
 
@@ -39,7 +39,7 @@ data TicketResponse
 
 instance FromJSON TicketResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateTicketEmailVerification
   :: (MonadIO m, MonadThrow m)
@@ -63,7 +63,7 @@ data TicketChangePassword
 
 instance ToJSON TicketChangePassword where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runCreateTicketChangePassword
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/UserBlocks.hs
+++ b/src/Auth0/Management/UserBlocks.hs
@@ -48,7 +48,7 @@ data UserBlockResponse
 
 instance FromJSON UserBlockResponse where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runGetUserBlocks
   :: (MonadIO m, MonadThrow m)

--- a/src/Auth0/Management/Users.hs
+++ b/src/Auth0/Management/Users.hs
@@ -65,7 +65,7 @@ data ProfileData
   , pdFamilyName    :: Maybe Text
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 } ''ProfileData
+deriveJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' . drop 2 } ''ProfileData
 
 data Identity
   = Identity
@@ -79,14 +79,14 @@ data Identity
 
 instance FromJSON Identity where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = f . drop 1 }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = f . drop 1 }
     where
       f "IsSocial" = "isSocial"
       f v          = camelTo2 '_' v
 
 instance ToJSON Identity where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = f . drop 1 }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = f . drop 1 }
     where
       f "IsSocial" = "isSocial"
       f v          = camelTo2 '_' v
@@ -116,7 +116,7 @@ data UserResponse appMd userMd
   , urFamilyName    :: Maybe Text
   } deriving (Generic, Show)
 
-deriveJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 } ''UserResponse
+deriveJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' . drop 2 } ''UserResponse
 
 runGetUsers
   :: (MonadIO m, MonadThrow m, FromJSON appMd, FromJSON userMd)
@@ -147,7 +147,7 @@ data UserCreate appMd userMd
 
 instance (ToJSON appMd, ToJSON userMd) => ToJSON (UserCreate appMd userMd) where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' . drop 2 }
 
 runCreateUser
   :: (MonadIO m, MonadThrow m, FromJSON appMd, FromJSON userMd, ToJSON appMd, ToJSON userMd, Show appMd, Show userMd)
@@ -218,7 +218,7 @@ data UserEnrollment
 
 instance FromJSON UserEnrollment where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = f . drop 2 }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = f . drop 2 }
     where
       f "type" = "etype"
       f v      = camelTo2 '_' v
@@ -269,7 +269,7 @@ data UserLog
 
 instance FromJSON UserLog where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' . drop 2 }
 
 runGetUserLogs
   :: (MonadIO m, MonadThrow m)
@@ -317,7 +317,7 @@ data GuardianRecoveryCode
 
 instance FromJSON GuardianRecoveryCode where
   parseJSON =
-    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+    genericParseJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' }
 
 runUserRecoveryCodeRegeneration
   :: (MonadIO m, MonadThrow m)
@@ -339,7 +339,7 @@ data LinkAccount
 
 instance ToJSON LinkAccount where
   toJSON =
-    genericToJSON defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2 }
+    genericToJSON defaultOptions { omitNothingFields = True, fieldLabelModifier = camelTo2 '_' . drop 2 }
 
 runUserLinkAccount
   :: (MonadIO m, MonadThrow m)


### PR DESCRIPTION
Optional parameters need to be omitted from the JSON body in order for the Auth0 api to correctly interpret them as such. If we simply set them to null, it will return validation errors, since it tries to use null values for those fields. E.g., if you send `phone_number=null` to the create user input, it returns an error saying that `null` is an invalid phone number.

Fortunately, this can easily be configured with an Aeson option that automatically omits all nothing fields from the derived JSON.